### PR TITLE
Use Chef::ServerAPI instead of Chef::REST

### DIFF
--- a/lib/chef/knife/runs_list.rb
+++ b/lib/chef/knife/runs_list.rb
@@ -67,7 +67,7 @@ class Chef
         :description => 'Filters by run status (success, failure, or aborted).'
 
       def run
-        @rest = Chef::REST.new(Chef::Config[:chef_server_url])
+        @rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
         node_name = name_args[0]
 
@@ -102,7 +102,7 @@ class Chef
       end
 
       def history(query_string)
-        runs = @rest.get_rest(query_string, false,  HEADERS)
+        runs = @rest.get_rest(query_string,  HEADERS)
 
         runs["run_history"].map do |run|
           { :run_id => run["run_id"],

--- a/lib/chef/knife/runs_show.rb
+++ b/lib/chef/knife/runs_show.rb
@@ -37,7 +37,7 @@ class Chef
       HEADERS = {'X-Ops-Reporting-Protocol-Version' => PROTOCOL_VERSION}
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
+        rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
         run_id = name_args[0]
 
@@ -51,11 +51,11 @@ class Chef
 
         query_string = "reports/org/runs/#{run_id}"
 
-        runs = rest.get(query_string, false, HEADERS)
+        runs = rest.get(query_string, HEADERS)
 
         if runs['run_detail']['updated_res_count'] > runs['run_resources'].length
           all_query = "#{query_string}?start=0&rows=#{runs['run_detail']['updated_res_count']}"
-          runs = rest.get(all_query, false, HEADERS)
+          runs = rest.get(all_query, HEADERS)
         end
         output(runs)
       end


### PR DESCRIPTION
Chef 12.7+ has moved to using Chef::ServerAPI for
internal API calls.

Reference: https://github.com/chef/chef/blob/12.7.2/RELEASE_NOTES.md#chefrest