### PR TITLE
Allow runs commands to accept many args

### DIFF
--- a/lib/chef/knife/runs_list.rb
+++ b/lib/chef/knife/runs_list.rb
@@ -69,15 +69,17 @@ class Chef
       def run
         @rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
-        node_name = name_args[0]
-
         check_start_and_end_times_provided()
         start_time, end_time = apply_time_args()
         check_3month_window(start_time, end_time)
 
-        query_string = generate_query(start_time, end_time, node_name, config[:rows],
-                                      config[:status])
-        runs = history(query_string)
+        runs = []
+
+        name_args.each do |node_name|
+          query_string = generate_query(start_time, end_time, node_name, config[:rows],
+                                        config[:status])
+          runs.push(history(query_string))
+        end
 
         output(runs)
       end

--- a/lib/chef/knife/runs_show.rb
+++ b/lib/chef/knife/runs_show.rb
@@ -39,26 +39,32 @@ class Chef
       def run
         rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
 
-        run_id = name_args[0]
+        runs = []
 
-        if run_id.nil?
-          show_usage
-          exit 1
-        elsif uuid?(run_id)
-          puts "Run ID should be a Chef Client Run ID, e.g: 11111111-1111-1111-1111-111111111111"
-          exit 1
-        end
+        name_args.each do |run_id|
 
-        query_string = "reports/org/runs/#{run_id}"
+          if run_id.nil?
+            show_usage
+            exit 1
+          elsif uuid?(run_id)
+            puts "Run ID should be a Chef Client Run ID, e.g: 11111111-1111-1111-1111-111111111111"
+            exit 1
+          end
 
-        runs = rest.get(query_string, HEADERS)
+          query_string = "reports/org/runs/#{run_id}"
 
-        if runs["run_detail"]["updated_res_count"] > runs["run_resources"].length
-          all_query = "#{query_string}?start=0&rows=#{runs['run_detail']['updated_res_count']}"
-          runs = rest.get(all_query, HEADERS)
+          run = rest.get(query_string, HEADERS)
+
+          if run['run_detail']['updated_res_count'] > run['run_resources'].length
+            all_query = "#{query_string}?start=0&rows=#{run['run_detail']['updated_res_count']}"
+            run = rest.get(all_query, HEADERS)
+          end
+
+          runs.push(run)
         end
         output(runs)
       end
     end
   end
 end
+


### PR DESCRIPTION
This is just a simple change to allow users to provide many node names when running knife runs list and knife runs show

Now users can do knife runs list <node1> <node2> <etc> and knife runs show <run_id_1> <run_id_2> <etc>

Before, if users ran the above, only node1's history and run_id_1s run report would be listed in the output, respectively.